### PR TITLE
Add security enhancements to nginx conf

### DIFF
--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -39,33 +39,9 @@ http {
         listen       80 default_server;
         listen       [::]:80 default_server;
         server_name  multinet.app;
- 
-        # Load configuration files for the default server block.
-        include /etc/nginx/default.d/*.conf;
-
-        location / {
-           proxy_pass http://127.0.0.1:8080/;
-        }
-
-        location /nodelink/ {
-           proxy_pass http://127.0.0.1:8081/;
-        }
-
-        location /adjmatrix/ {
-           proxy_pass http://127.0.0.1:8082/;
-        }
-
-        location /webhook/ {
-           proxy_pass http://127.0.0.1:4112/;
-        }
-
-        error_page 404 /404.html;
-            location = /40x.html {
-        }
-
-        error_page 500 502 503 504 /50x.html;
-            location = /50x.html {
-        }
+        
+        # Redirect to the https version of the site
+        return 301 https://$host$request_uri;
     }
 
 
@@ -73,14 +49,32 @@ http {
         listen       443 ssl http2;
         listen       [::]:443 ssl http2;
         server_name  multinet.app;
-        root         /usr/share/nginx/html;
+        server_tokens off;
 
+        # Resist clickjacking
+        add_header X-Frame-Options SAMEORIGIN;
+
+        # Resist mime-type sniffing
+        add_header X-Content-Type-Options nosniff;
+
+        # Enables the Cross-site scripting (XSS) filter
+        add_header X-XSS-Protection "1; mode=block";
+        
+        # Enable HTST
+        add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+
+        # SSL 
         ssl_certificate "/etc/letsencrypt/live/multinet.app/fullchain.pem";
         ssl_certificate_key "/etc/letsencrypt/live/multinet.app/privkey.pem";
-        ssl_session_cache shared:SSL:1m;
+        ssl_session_cache shared:SSL:10m;
         ssl_session_timeout  10m;
-        ssl_ciphers HIGH:!aNULL:!MD5;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        #ssl_ciphers HIGH:!aNULL:!MD5; #default
         ssl_prefer_server_ciphers on;
+        # Generated Diffie-Hellman group location
+        ssl_dhparam /etc/nginx/tls/dhparam.pem
+        ssl_ecdh_curve secp384r1;
+        ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4;
 
         # Load configuration files for the default server block.
         include /etc/nginx/default.d/*.conf;

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -1,7 +1,3 @@
-# For more information on configuration, see:
-#   * Official English Documentation: http://nginx.org/en/docs/
-#   * Official Russian Documentation: http://nginx.org/ru/docs/
-
 user nginx;
 worker_processes auto;
 error_log /var/log/nginx/error.log;
@@ -30,11 +26,6 @@ http {
     include             /etc/nginx/mime.types;
     default_type        application/octet-stream;
 
-    # Load modular configuration files from the /etc/nginx/conf.d directory.
-    # See http://nginx.org/en/docs/ngx_core_module.html#include
-    # for more information.
-    include /etc/nginx/conf.d/*.conf;
-
     server {
         listen       80 default_server;
         listen       [::]:80 default_server;
@@ -43,7 +34,6 @@ http {
         # Redirect to the https version of the site
         return 301 https://$host$request_uri;
     }
-
 
     server {
         listen       443 ssl http2;
@@ -69,15 +59,11 @@ http {
         ssl_session_cache shared:SSL:10m;
         ssl_session_timeout  10m;
         ssl_protocols TLSv1.2 TLSv1.3;
-        #ssl_ciphers HIGH:!aNULL:!MD5; #default
         ssl_prefer_server_ciphers on;
         # Generated Diffie-Hellman group location
         ssl_dhparam /etc/nginx/tls/dhparams.pem;
         ssl_ecdh_curve secp384r1;
         ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
-
-        # Load configuration files for the default server block.
-        include /etc/nginx/default.d/*.conf;
 
         location / {
            proxy_pass http://127.0.0.1:8080/;
@@ -103,5 +89,4 @@ http {
             location = /50x.html {
         }
     }
-
 }

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -68,7 +68,7 @@ http {
         ssl_certificate_key "/etc/letsencrypt/live/multinet.app/privkey.pem";
         ssl_session_cache shared:SSL:10m;
         ssl_session_timeout  10m;
-        ssl_protocols TLSv1.2;
+        ssl_protocols TLSv1.2 TLSv1.3;
         #ssl_ciphers HIGH:!aNULL:!MD5; #default
         ssl_prefer_server_ciphers on;
         # Generated Diffie-Hellman group location

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -72,7 +72,7 @@ http {
         #ssl_ciphers HIGH:!aNULL:!MD5; #default
         ssl_prefer_server_ciphers on;
         # Generated Diffie-Hellman group location
-        ssl_dhparam /etc/nginx/tls/dhparam.pem;
+        ssl_dhparam /etc/nginx/tls/dhparams.pem;
         ssl_ecdh_curve secp384r1;
         ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4;
 

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -68,7 +68,7 @@ http {
         ssl_certificate_key "/etc/letsencrypt/live/multinet.app/privkey.pem";
         ssl_session_cache shared:SSL:10m;
         ssl_session_timeout  10m;
-        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_protocols TLSv1.2;
         #ssl_ciphers HIGH:!aNULL:!MD5; #default
         ssl_prefer_server_ciphers on;
         # Generated Diffie-Hellman group location

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -74,7 +74,7 @@ http {
         # Generated Diffie-Hellman group location
         ssl_dhparam /etc/nginx/tls/dhparams.pem;
         ssl_ecdh_curve secp384r1;
-        ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4;
+        ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
 
         # Load configuration files for the default server block.
         include /etc/nginx/default.d/*.conf;

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -72,7 +72,7 @@ http {
         #ssl_ciphers HIGH:!aNULL:!MD5; #default
         ssl_prefer_server_ciphers on;
         # Generated Diffie-Hellman group location
-        ssl_dhparam /etc/nginx/tls/dhparam.pem
+        ssl_dhparam /etc/nginx/tls/dhparam.pem;
         ssl_ecdh_curve secp384r1;
         ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4;
 


### PR DESCRIPTION
Closes #4. Using these sources, I've upgraded the security. The full list of enhancements is below.

https://tylermade.net/2017/05/01/nginx-security-hardening/
https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
https://www.acunetix.com/blog/articles/nginx-server-security-hardening-configuration-1/

- Don't allow any http, auto redirect to https
- No server tokens so our nginx version is not leaked
- Verified that our openSSL version is not vulnerable to heartbleed
- Resist clickjacking
- Resist mime type sniffing
- Enable XSS filter
- Enable HTST
- Generated a stronger Diffie-Hellman group
- Set protocols to TLS 1.2 and 1.3
- Limited to strong ciphers (has some compatibility with older browsers so we might open this up a little)