### PR TITLE
Add a config to the nginx setup that auto upgrades requests from port 80 to 443

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -83,6 +83,12 @@
               ssl_protocols TLSv1.2 TLSv1.3;
               ssl_prefer_server_ciphers on;
               ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
+          - listen: "80"
+            server_name: "multinet.app"
+            state: "present"
+            filename: "multinet80.app.conf"
+            extra_parameters: |
+              return 301 https://$host$request_uri;
       nginx_remove_default_vhost: true
       become: true
 


### PR DESCRIPTION
Add another server block and save as a separate config in multinet80.app.conf. This has already rebuilt the live interface and it appears to be working