### PR TITLE
Update installed python version and remove pipenv flag

### DIFF
--- a/tasks/server_tasks.yml
+++ b/tasks/server_tasks.yml
@@ -1,9 +1,10 @@
-- name: Install python3 and pip
+- name: Install python3.7 and pip
   apt:
     pkg:
-      - python3-dev
+      - python3.7
+      - python3.7-dev
+      - python3.7-venv
       - python3-pip
-      - python3-venv
     update_cache: true
   become: true
 
@@ -33,7 +34,7 @@
   become: true
 
 - name: Install python server dependencies
-  command: pipenv install --python /usr/bin/python3
+  command: pipenv install
   args:
     chdir: "{{ multinet_server_path }}"
   when: multinet_git.changed


### PR DESCRIPTION
This is intended to fix our breaking deploys, however I'm not an expert in this so I'm not sure if this is the proper way to go about it. Please let me know what you think and if there's anything missing.